### PR TITLE
Remove unecessary txt ext

### DIFF
--- a/guidelines/pride-submission-validation.yaml
+++ b/guidelines/pride-submission-validation.yaml
@@ -95,7 +95,7 @@
 #
 # ==============================================================================
 
-version: "2.0.0"
+version: "2.0.1"
 description: "PRIDE submission validation rules — machine-readable source of truth"
 
 # ------------------------------------------------------------------------------
@@ -943,7 +943,6 @@ tools:
       - name: dependentPeptides.txt
         status: optional
         category: ANALYSIS
-        extensions: [.txt]
         filename_patterns: ["{prefix}dependentPeptides.txt"]
         description: "Dependent peptide analysis results"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for MaxQuant submissions by matching `dependentPeptides.txt` files using their expected filename pattern.
  * Prevented unrelated `.txt` files from being incorrectly identified as `dependentPeptides.txt`.

* **Documentation**
  * Updated the PRIDE submission validation schema version to 2.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->