### PR TITLE
Remove common extensions as analysis category in OTHER tool profile

### DIFF
--- a/guidelines/pride-submission-validation.yaml
+++ b/guidelines/pride-submission-validation.yaml
@@ -95,7 +95,7 @@
 #
 # ==============================================================================
 
-version: "2.0.3"
+version: "2.0.4"
 description: "PRIDE submission validation rules — machine-readable source of truth"
 
 # ------------------------------------------------------------------------------
@@ -1990,7 +1990,7 @@ tools:
       - name: analysis_files
         status: mandatory
         category: ANALYSIS
-        extensions: [.txt, .tsv, .csv, .pep.xml, .idxml, .dat, .pdresult, .parquet, .mzid, .mzTab]
+        extensions: [.pep.xml, .idxml, .dat, .pdresult, .parquet, .mzid, .mzTab]
         description: "Search results in native format from the analysis tool"
         content_verification:
           method: file_not_empty

--- a/guidelines/pride-submission-validation.yaml
+++ b/guidelines/pride-submission-validation.yaml
@@ -2005,7 +2005,7 @@ tools:
       - name: parameter_files
         status: recommended
         category: OTHER
-        extensions: [.txt, .xml, .params, .cfg, .json]
+        extensions: [.txt, .tsv, .csv, .xml, .params, .cfg, .json]
         description: "Parameter files or detailed documentation of settings"
 
       - *common_peak_lists


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the PRIDE submission validation schema to version **2.0.4**.
  * Refined generic file validation: analysis-file matching now excludes **.txt/.tsv/.csv**, while allowing formats like **.pep.xml, .idxml, .dat, .pdresult, .parquet, .mzid, .mzTab**.
  * Expanded generic parameter-file matching to also accept **.tsv** and **.csv** (in addition to existing supported types).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->